### PR TITLE
Swap type parameter order in SmallUnliftedArray and SmallMutableUnliftedArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## 2.2.0.0 -- 2024-10-05
+
+* Similarly to the change in 2.1.0.0, change the order of the type arguments to `SmallUnliftedArray_` and
+  `SmallMutableUnliftedArray_`. This makes the library work better with
+  the typeclasses in the `contiguous` library.
+
 ## 2.1.0.0 -- 2023-06-28
 
 * Change the order of the type arguments to `UnliftedArray_` and

--- a/src/Data/Primitive/Unlifted/SmallArray/Primops.hs
+++ b/src/Data/Primitive/Unlifted/SmallArray/Primops.hs
@@ -13,8 +13,8 @@
 -- primops for manipulating them.
 module Data.Primitive.Unlifted.SmallArray.Primops
   ( -- * Types
-    SmallUnliftedArray#
-  , SmallMutableUnliftedArray#
+    SmallUnliftedArray#(..)
+  , SmallMutableUnliftedArray#(..)
     -- We don't export the newtype constructors because they're bogus and
     -- because there's basically no reason they'd ever be used. This module
     -- contains a wrapped version of every Array# primop.  Eventually, all this

--- a/src/Data/Primitive/Unlifted/SmallArray/ST.hs
+++ b/src/Data/Primitive/Unlifted/SmallArray/ST.hs
@@ -78,30 +78,30 @@ primitive_ m = ST (\s -> (# m s, () #))
 -- It is expected that @unlifted_a ~ Unlifted a@, but imposing that constraint
 -- here would force the type roles to @nominal@, which is often undesirable
 -- when arrays are used as components of larger datatypes.
-data SmallUnliftedArray_ a unlifted_a
+data SmallUnliftedArray_ unlifted_a a 
   = SmallUnliftedArray (SmallUnliftedArray# unlifted_a)
-type role SmallUnliftedArray_ phantom representational
+type role SmallUnliftedArray_ representational phantom 
 
 -- | A type synonym for a 'SmallUnliftedArray_' containing lifted values of
 -- a particular type. As a general rule, this type synonym should not be used in
 -- class instances—use 'SmallUnliftedArray_' with an equality constraint instead.
 -- It also should not be used when defining newtypes or datatypes, unless those
 -- will have restrictive type roles regardless—use 'SmallUnliftedArray_' instead.
-type SmallUnliftedArray a = SmallUnliftedArray_ a (Unlifted a)
+type SmallUnliftedArray a = SmallUnliftedArray_ (Unlifted a) a 
 
-data SmallMutableUnliftedArray_ s a unlifted_a
+data SmallMutableUnliftedArray_ unlifted_a s a
   = SmallMutableUnliftedArray (SmallMutableUnliftedArray# s unlifted_a)
-type role SmallMutableUnliftedArray_ nominal phantom representational
+type role SmallMutableUnliftedArray_ representational nominal phantom 
 
-type SmallMutableUnliftedArray s a = SmallMutableUnliftedArray_ s a (Unlifted a)
+type SmallMutableUnliftedArray s a = SmallMutableUnliftedArray_ (Unlifted a) s a 
 
-instance unlifted_a ~ Unlifted a => PrimUnlifted (SmallUnliftedArray_ a unlifted_a) where
-  type Unlifted (SmallUnliftedArray_ _ unlifted_a) = SmallUnliftedArray# unlifted_a
+instance unlifted_a ~ Unlifted a => PrimUnlifted (SmallUnliftedArray_ unlifted_a a) where
+  type Unlifted (SmallUnliftedArray_ unlifted_a _) = SmallUnliftedArray# unlifted_a
   toUnlifted# (SmallUnliftedArray a) = a
   fromUnlifted# x = SmallUnliftedArray x
 
-instance unlifted_a ~ Unlifted a => PrimUnlifted (SmallMutableUnliftedArray_ s a unlifted_a) where
-  type Unlifted (SmallMutableUnliftedArray_ s _ unlifted_a) = SmallMutableUnliftedArray# s unlifted_a
+instance unlifted_a ~ Unlifted a => PrimUnlifted (SmallMutableUnliftedArray_ unlifted_a s a) where
+  type Unlifted (SmallMutableUnliftedArray_ unlifted_a s _) = SmallMutableUnliftedArray# s unlifted_a 
   toUnlifted# (SmallMutableUnliftedArray a) = a
   fromUnlifted# x = SmallMutableUnliftedArray x
 
@@ -511,28 +511,28 @@ smallUnliftedArrayFromListN len vs = unsafeCreateSmallUnliftedArray len run wher
     go vs 0
 
 instance (PrimUnlifted a, unlifted_a ~ Unlifted a)
-  => Exts.IsList (SmallUnliftedArray_ a unlifted_a) where
-  type Item (SmallUnliftedArray_ a _) = a
+  => Exts.IsList (SmallUnliftedArray_ unlifted_a a) where
+  type Item (SmallUnliftedArray_ _ a) = a
   fromList = smallUnliftedArrayFromList
   fromListN = smallUnliftedArrayFromListN
   toList = smallUnliftedArrayToList
 
 instance (PrimUnlifted a, unlifted_a ~ Unlifted a)
-  => Semigroup (SmallUnliftedArray_ a unlifted_a) where
+  => Semigroup (SmallUnliftedArray_ unlifted_a a) where
   (<>) = concatSmallUnliftedArray
 
-instance (PrimUnlifted a, unlifted_a ~ Unlifted a) => Monoid (SmallUnliftedArray_ a unlifted_a) where
+instance (PrimUnlifted a, unlifted_a ~ Unlifted a) => Monoid (SmallUnliftedArray_ unlifted_a a) where
   mempty = emptySmallUnliftedArray
 
-instance (Show a, PrimUnlifted a, unlifted_a ~ Unlifted a) => Show (SmallUnliftedArray_ a unlifted_a) where
+instance (Show a, PrimUnlifted a, unlifted_a ~ Unlifted a) => Show (SmallUnliftedArray_ unlifted_a a) where
   showsPrec p a = showParen (p > 10) $
     showString "fromListN " . shows (sizeofSmallUnliftedArray a) . showString " "
       . shows (smallUnliftedArrayToList a)
 
-instance unlifted_a ~ Unlifted a => Eq (SmallMutableUnliftedArray_ s a unlifted_a) where
+instance unlifted_a ~ Unlifted a => Eq (SmallMutableUnliftedArray_ unlifted_a s a) where
   (==) = sameSmallMutableUnliftedArray
 
-instance (Eq a, PrimUnlifted a, unlifted_a ~ Unlifted a) => Eq (SmallUnliftedArray_ a unlifted_a) where
+instance (Eq a, PrimUnlifted a, unlifted_a ~ Unlifted a) => Eq (SmallUnliftedArray_ unlifted_a a) where
   aa1 == aa2 = sizeofSmallUnliftedArray aa1 == sizeofSmallUnliftedArray aa2
             && loop (sizeofSmallUnliftedArray aa1 - 1)
    where

--- a/src/Data/Primitive/Unlifted/SmallArray/ST.hs
+++ b/src/Data/Primitive/Unlifted/SmallArray/ST.hs
@@ -131,7 +131,7 @@ setSmallUnliftedArray mua v off len = loop (len + off - 1)
    | otherwise = writeSmallUnliftedArray mua i v *> loop (i-1)
 
 -- | Yields the length of an 'UnliftedArray'.
-sizeofSmallUnliftedArray :: SmallUnliftedArray e -> Int
+sizeofSmallUnliftedArray :: SmallUnliftedArray_ unlifted_e e -> Int
 {-# inline sizeofSmallUnliftedArray #-}
 sizeofSmallUnliftedArray (SmallUnliftedArray ar) = I# (sizeofSmallUnliftedArray# ar)
 
@@ -182,8 +182,8 @@ unsafeFreezeSmallUnliftedArray (SmallMutableUnliftedArray maa#)
 -- | Determines whether two 'MutableUnliftedArray' values are the same. This is
 -- object/pointer identity, not based on the contents.
 sameSmallMutableUnliftedArray
-  :: SmallMutableUnliftedArray s a
-  -> SmallMutableUnliftedArray s a
+  :: SmallMutableUnliftedArray_ unlifted_a s a
+  -> SmallMutableUnliftedArray_ unlifted_a s a
   -> Bool
 sameSmallMutableUnliftedArray (SmallMutableUnliftedArray maa1#) (SmallMutableUnliftedArray maa2#)
   = Exts.isTrue# (sameSmallMutableUnliftedArray# maa1# maa2#)
@@ -345,7 +345,7 @@ cloneSmallMutableUnliftedArray (SmallMutableUnliftedArray mary) (I# off) (I# len
   = ST $ \s -> case cloneSmallMutableUnliftedArray# mary off len s of
       (# s', mary' #) -> (# s', SmallMutableUnliftedArray mary' #)
 
-emptySmallUnliftedArray :: SmallUnliftedArray a
+emptySmallUnliftedArray :: SmallUnliftedArray_ unlifted_a a
 emptySmallUnliftedArray = SmallUnliftedArray (emptySmallUnliftedArray# (##))
 
 singletonSmallUnliftedArray :: PrimUnlifted a => a -> SmallUnliftedArray a


### PR DESCRIPTION
This change makes the unboxed parameter the first one.

- [x] Change type parameter order of `SmallUnliftedArray_`
- [x] Change type parameter order of `SmallMutableUnliftedArray_`
- [x] Make sure to expose the newtype constructors of `SmallUnliftedArray#` and `SmallMutableUnliftedArray#` (This mirrors the exports from `Array.Primops`)
- [x] Loosen the signatures of `emptySmalUnliftedArray` and `sameMutableUnliftedArray` to work on the more general types with unconstrained `unlifted_a`. (This mirrors the definitions for `Array`)
- [x] Adding an entry to the CHANGELOG _(NOTE: Expecting this to be released as v 2.2.0.0, similar to the last change)_

Fixes #43